### PR TITLE
Make script more portable

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -102,10 +102,12 @@ if [ "$overwrite" = true ]; then
         xdg-open "$dest_dir" || true
     fi
 
+    script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
     # Copy the directory and files recursively
-    cp -R "vendor/${files[0]}" "$dest_dir"
-    cp "vendor/${files[1]}" "$dest_dir"
-    cp "vendor/${files[2]}" "$dest_dir"
+    cp -R "$script_dir/vendor/${files[0]}" "$dest_dir"
+    cp "$script_dir/vendor/${files[1]}" "$dest_dir"
+    cp "$script_dir/vendor/${files[2]}" "$dest_dir"
     
     echo "Files and directory copied successfully."
 fi

--- a/install.sh
+++ b/install.sh
@@ -102,7 +102,7 @@ if [ "$overwrite" = true ]; then
         xdg-open "$dest_dir" || true
     fi
 
-    script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+    script_dir=$(dirname "$0")
 
     # Copy the directory and files recursively
     cp -R "$script_dir/vendor/${files[0]}" "$dest_dir"


### PR DESCRIPTION
If a user drops the install.sh script into a terminal, they will get error 

```
cp: vendor/AnkerMakeCE: No such file or directory
cp: vendor/AnkerMakeCE.idx: No such file or directory
cp: vendor/AnkerMakeCE.ini: No such file or directory
```

Handle that edge case by finding the path of the script and using a full path instead of assuming the PWD is where the install.sh script is. 