### PR TITLE
fix: correct linux directories and proper error handling when no directories are found

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2,54 +2,54 @@
 
 # Function to check for macOS PrusaSlicer directories
 mac_directories() {
-    directories=()
     if [ -d "$HOME/Library/Application Support/PrusaSlicer" ]; then
-        directories+=("$HOME/Library/Application Support/PrusaSlicer")
+        echo "$HOME/Library/Application Support/PrusaSlicer"
     fi
     if [ -d "$HOME/Library/Application Support/PrusaSlicer-alpha" ]; then
-        directories+=("$HOME/Library/Application Support/PrusaSlicer-alpha")
+        echo "$HOME/Library/Application Support/PrusaSlicer-alpha"
     fi
     if [ -d "$HOME/Library/Application Support/PrusaSlicer-beta" ]; then
-        directories+=("$HOME/Library/Application Support/PrusaSlicer-beta")
+        echo "$HOME/Library/Application Support/PrusaSlicer-beta"
     fi
-
-    printf '%s\n' "${directories[@]}"
 }
 
 # Function to check for Linux PrusaSlicer directories
 linux_directories() {
-    directories=()
-    #TODO: Test and verify which directories show up on linux systems
     if [ -d "$HOME/.PrusaSlicer" ]; then
-        directories+=("$HOME/.PrusaSlicer")
+        echo "$HOME/.PrusaSlicer"
     fi
-
-    printf '%s\n' "${directories[@]}"
+    if [ -d "$HOME/.config/PrusaSlicer" ]; then
+        echo "$HOME/.config/PrusaSlicer"
+    fi
+    if [ -d "$HOME/.config/PrusaSlicer-alpha" ]; then
+        echo "$HOME/.config/PrusaSlicer-alpha"
+    fi
+    if [ -d "$HOME/.config/PrusaSlicer-beta" ]; then
+        echo "$HOME/.config/PrusaSlicer-beta"
+    fi
 }
 
-# Detect the operating system
+# Detect the operating system and get the directories
+directories=()
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-    # Linux
-    PRUSASLICER_DIR=$(linux_directories)
+    directories=($(linux_directories))
 elif [[ "$OSTYPE" == "darwin"* ]]; then
-    # MacOS
-    PRUSASLICER_DIR=$(mac_directories)
+    directories=($(mac_directories))
 else
     echo "Unsupported operating system."
     exit 1
 fi
 
 # Check the number of directories found
-count=$(echo "$PRUSASLICER_DIR" | wc -l)
+count=${#directories[@]}
 if [ "$count" -eq 0 ]; then
     echo "PrusaSlicer directories not found."
     exit 1
 elif [ "$count" -eq 1 ]; then
-    chosen_dir=$(echo "$PRUSASLICER_DIR" | head -1)
+    chosen_dir="${directories[0]}"
 else
     echo "Multiple PrusaSlicer directories found."
     echo "Please choose which one you want to use:"
-    IFS=$'\n' read -r -d '' -a directories <<< "$PRUSASLICER_DIR"
     select slicer_dir in "${directories[@]}"; do
         chosen_dir="$slicer_dir"
         break
@@ -57,8 +57,6 @@ else
 fi
 
 echo "You chose: $chosen_dir"
-
-# Continue with further actions using "$chosen_dir"
 
 # Destination directory
 dest_dir="$chosen_dir/vendor"

--- a/install.sh
+++ b/install.sh
@@ -30,6 +30,7 @@ linux_directories() {
 }
 
 # Detect the operating system and get the directories
+IFS=$'\n'
 directories=()
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
     directories=($(linux_directories))
@@ -39,6 +40,7 @@ else
     echo "Unsupported operating system."
     exit 1
 fi
+IFS=' \t\n'
 
 # Check the number of directories found
 count=${#directories[@]}


### PR DESCRIPTION
Related issue: #15. 

### Summary of changes 

1. The `linux_directories` function has been updated to correctly locate the PrusaSlicer directory on Linux systems. It now checks both `$HOME/.PrusaSlicer` and `$HOME/.config/PrusaSlicer`, including the Beta and Alpha versions.
2. The script now accurately counts the number of directories in the directories array using `${#array[@]}`, replacing the previous method of using `wc -l`.