### PR TITLE
Add '*TPU*' and 'Generic TPU 95A @ANKER-CE' filament profiles

### DIFF
--- a/vendor/AnkerMakeCE.ini
+++ b/vendor/AnkerMakeCE.ini
@@ -295,6 +295,23 @@ max_fan_speed = 30
 min_fan_speed = 20
 temperature = 240
 
+[filament:*TPU*]
+inherits = *common*
+bed_temperature = 30
+bridge_fan_speed = 50
+extrusion_multiplier = 1.03
+disable_fan_first_layers = 3
+full_fan_speed_layer = 3
+filament_colour = #8000FF
+filament_density = 1.24
+filament_max_volumetric_speed = 1.8
+filament_type = TPU
+first_layer_bed_temperature = 30
+first_layer_temperature = 225
+max_fan_speed = 80
+min_fan_speed = 30
+temperature = 225
+
 [filament:Generic PLA @ANKER-CE]
 inherits = *PLA*
 compatible_printers_condition = printer_model=~/(M5-CE).*/
@@ -320,6 +337,17 @@ filament_retract_before_wipe = 100
 inherits = *ABS*
 compatible_printers_condition = printer_model=~/(M5-CE).*/
 filament_vendor = Generic
+
+[filament:Generic TPU 95A @ANKER-CE]
+inherits = *TPU*
+compatible_printers_condition = printer_model=~/(M5-CE).*/
+filament_vendor = Generic
+filament_retract_length = 3.5
+filament_retract_speed = 90
+filament_deretract_speed = 50
+filament_retract_layer_change = 1
+filament_wipe = 1
+filament_retract_before_wipe = 100%
 
 # Common printer preset
 [printer:*common*]


### PR DESCRIPTION
Hello!
This PR adds a profile for 95A TPU filament.

A few notes:

- This has currently only been tested with Overture TPU (the standard kind)
- The slow speed was calculated via volumetric flow testing
- I read somewhere that TPU always under-extrudes, and that was certainly true in my tests, so I set the standard extrusion multiplier to 1.03 rather than the standard 0.97

Happy to answer additional questions or talk more.