### PR TITLE
AnkerSlicer default setting for first_layer_speed is 50 mm/s -> first…

### DIFF
--- a/vendor/AnkerMakeCE.ini
+++ b/vendor/AnkerMakeCE.ini
@@ -58,8 +58,9 @@ first_layer_acceleration = 2500
 first_layer_acceleration_over_raft = 500
 first_layer_extrusion_width = 0.45
 first_layer_height = 0.20
-first_layer_speed = 50%
-first_layer_speed_over_raft = 50%
+# AnkerSlicer default setting for first_layer_speed is 50 mm/s -> first lay with a higher speed won't be successful
+first_layer_speed = 50
+first_layer_speed_over_raft = 50
 gap_fill_speed = 150
 gcode_resolution = 0.008
 infill_acceleration = 2500


### PR DESCRIPTION
… layer with a higher speed won't be successful

first_layer_speed = 50